### PR TITLE
(maint) Add flag to ignore :latest validation errors

### DIFF
--- a/docs/parsers.md
+++ b/docs/parsers.md
@@ -57,3 +57,4 @@ The available settings are:
 | --------------------| ----------- |
 | `Dependency/Puppet` | Instructs the resolver to ignore any Puppet version in its dependency traversal for the specified modules. Useful for modules with outdated metadata.json information |
 | `Dependency/All`    | Instructs the resolver to ignore any, and all, dependencies in its dependency traversal of the specified module. Useful for modules with outdated metadata.json information. |
+| `Validation/LatestVersion` | Instructs the resolution validator to ignore modules that have a version of :latest |

--- a/lib/puppetfile-resolver/puppetfile.rb
+++ b/lib/puppetfile-resolver/puppetfile.rb
@@ -6,9 +6,11 @@ module PuppetfileResolver
     #
     # DISABLE_PUPPET_DEPENDENCY_FLAG - Instructs the resolver to not consider Puppet version in its dependency traversal. Useful for modules with outdated metadata.json information.
     # DISABLE_ALL_DEPENDENCIES_FLAG - Instructs the resolver to ignore any dependencies in its dependency traversal. Useful for modules with outdated metadata.json information.
+    # DISABLE_LATEST_VALIDATION_FLAG - Instructs the resolution validator to ignore modules that have a version of :latest
     #
     DISABLE_PUPPET_DEPENDENCY_FLAG = :disable_puppet_dependency
     DISABLE_ALL_DEPENDENCIES_FLAG = :disable_all_dependencies
+    DISABLE_LATEST_VALIDATION_FLAG = :disable_latest_validation
   end
 end
 

--- a/lib/puppetfile-resolver/puppetfile/document.rb
+++ b/lib/puppetfile-resolver/puppetfile/document.rb
@@ -75,6 +75,7 @@ module PuppetfileResolver
           next unless mod.version == :latest
           resolved_module = resolution_result.specifications[mod.name]
           next if resolved_module.nil? || resolved_module.is_a?(PuppetfileResolver::Models::MissingModuleSpecification)
+          next if mod.resolver_flags.include?(PuppetfileResolver::Puppetfile::DISABLE_LATEST_VALIDATION_FLAG)
           @validation_errors << DocumentLatestVersionError.new(
             "Latest version of #{mod.name} is #{resolved_module.version}",
             mod,

--- a/lib/puppetfile-resolver/puppetfile/parser/r10k_eval.rb
+++ b/lib/puppetfile-resolver/puppetfile/parser/r10k_eval.rb
@@ -105,6 +105,8 @@ module PuppetfileResolver
               PuppetfileResolver::Puppetfile::DISABLE_PUPPET_DEPENDENCY_FLAG
             when 'dependency/all'
               PuppetfileResolver::Puppetfile::DISABLE_ALL_DEPENDENCIES_FLAG
+            when 'validation/latestversion'
+              PuppetfileResolver::Puppetfile::DISABLE_LATEST_VALIDATION_FLAG
             else # rubocop:disable Style/EmptyElse We will be adding something here later
               # TODO: Should we log a warning/info here?
               nil

--- a/spec/unit/puppetfile-resolver/puppetfile/document_spec.rb
+++ b/spec/unit/puppetfile-resolver/puppetfile/document_spec.rb
@@ -126,6 +126,7 @@ describe 'PuppetfileResolver::Puppetfile::Document' do
       @document_modules = document_fixtures.map do |doc_mod|
         mod = doc_mod[:class].new(doc_mod[:name])
         mod.version = doc_mod[:version]
+        mod.resolver_flags = doc_mod[:flags] unless doc_mod[:flags].nil?
         subject.add_module(mod)
         mod
       end
@@ -206,6 +207,19 @@ describe 'PuppetfileResolver::Puppetfile::Document' do
           module_specification: @module_specifications['foo'],
           puppet_module: @document_modules[0]
         )
+      end
+
+      context 'and using the DISABLE_LATEST_VALIDATION_FLAG flag' do
+        let(:document_fixtures) do
+          [
+            { class: PuppetfileResolver::Puppetfile::ForgeModule, name: 'foo', version: :latest, flags: [PuppetfileResolver::Puppetfile::DISABLE_LATEST_VALIDATION_FLAG] }
+          ]
+        end
+
+        it 'should not return a DocumentLatestVersionError' do
+          errors = subject.resolution_validation_errors(resolution_result)
+          expect(errors.count).to eq(0)
+        end
       end
     end
 

--- a/spec/unit/puppetfile-resolver/puppetfile/parser/r10k_eval_spec.rb
+++ b/spec/unit/puppetfile-resolver/puppetfile/parser/r10k_eval_spec.rb
@@ -351,6 +351,7 @@ RSpec.shared_examples "a puppetfile parser with magic comments" do
 
       mod 'puppetlabs-magic1', :latest # resolver:disable Dependency/Puppet
       mod 'puppetlabs-magic2', :latest # resolver:disable Dependency/all
+      mod 'puppetlabs-magic3', :latest # resolver:disable Validation/LatestVersion
       EOT
     end
     let(:puppetfile) { subject.parse(puppetfile_content) }
@@ -363,6 +364,11 @@ RSpec.shared_examples "a puppetfile parser with magic comments" do
     it 'should add the DISABLE_ALL_DEPENDENCIES_FLAG flag for Dependency/All' do
       mod = get_module(puppetfile, 'puppetlabs-magic2')
       expect(mod.resolver_flags).to eq([PuppetfileResolver::Puppetfile::DISABLE_ALL_DEPENDENCIES_FLAG])
+    end
+
+    it 'should add the DISABLE_LATEST_VALIDATION_FLAG flag for Validation/LatestVersion' do
+      mod = get_module(puppetfile, 'puppetlabs-magic3')
+      expect(mod.resolver_flags).to eq([PuppetfileResolver::Puppetfile::DISABLE_LATEST_VALIDATION_FLAG])
     end
   end
 end


### PR DESCRIPTION
Previously the resolution validator would raise an error if the PuppetFile
document specified a version of :latest, as typically this is bad idea. However
there are cases when this is required.  This commit adds a flag so that the
validator does NOT raise an error.