### PR TITLE
(GH-7) Update documentation

### DIFF
--- a/docs/example_usage.md
+++ b/docs/example_usage.md
@@ -14,6 +14,7 @@ puppetfile_path = '/path/to/Puppetfile'
 
 # Parse the Puppetfile into an object model
 content = File.open(puppetfile_path, 'rb') { |f| f.read }
+require 'puppetfile-resolver'
 require 'puppetfile-resolver/puppetfile/parser/r10k_eval'
 puppetfile = ::PuppetfileResolver::Puppetfile::Parser::R10KEval.parse(content)
 

--- a/docs/reference/PuppetfileResolver.html
+++ b/docs/reference/PuppetfileResolver.html
@@ -119,9 +119,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:47 2020 by
+  Generated on Thu Jun  4 18:14:23 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Cache.html
+++ b/docs/reference/PuppetfileResolver/Cache.html
@@ -107,9 +107,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:47 2020 by
+  Generated on Thu Jun  4 18:14:23 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Cache/Base.html
+++ b/docs/reference/PuppetfileResolver/Cache/Base.html
@@ -433,9 +433,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:47 2020 by
+  Generated on Thu Jun  4 18:14:23 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Cache/Persistent.html
+++ b/docs/reference/PuppetfileResolver/Cache/Persistent.html
@@ -422,9 +422,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:47 2020 by
+  Generated on Thu Jun  4 18:14:23 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Models.html
+++ b/docs/reference/PuppetfileResolver/Models.html
@@ -107,9 +107,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:47 2020 by
+  Generated on Thu Jun  4 18:14:23 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Models/MissingModuleSpecification.html
+++ b/docs/reference/PuppetfileResolver/Models/MissingModuleSpecification.html
@@ -375,9 +375,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Models/ModuleDependency.html
+++ b/docs/reference/PuppetfileResolver/Models/ModuleDependency.html
@@ -589,9 +589,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Models/ModuleSpecification.html
+++ b/docs/reference/PuppetfileResolver/Models/ModuleSpecification.html
@@ -957,9 +957,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Models/PuppetDependency.html
+++ b/docs/reference/PuppetfileResolver/Models/PuppetDependency.html
@@ -479,9 +479,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Models/PuppetSpecification.html
+++ b/docs/reference/PuppetfileResolver/Models/PuppetSpecification.html
@@ -455,9 +455,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Models/PuppetfileDependency.html
+++ b/docs/reference/PuppetfileResolver/Models/PuppetfileDependency.html
@@ -291,9 +291,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile.html
@@ -174,9 +174,9 @@ DISABLE_LATEST_VALIDATION_FLAG - Instructs the resolution validator to ignore mo
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:47 2020 by
+  Generated on Thu Jun  4 18:14:23 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/BaseModule.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/BaseModule.html
@@ -774,9 +774,9 @@ set out in the PuppetfileResolver::Puppetfile::..._FLAG constants</p>
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/Document.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/Document.html
@@ -903,9 +903,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:47 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/DocumentCircularDependencyError.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/DocumentCircularDependencyError.html
@@ -269,9 +269,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/DocumentDuplicateModuleError.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/DocumentDuplicateModuleError.html
@@ -289,9 +289,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/DocumentInvalidModuleError.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/DocumentInvalidModuleError.html
@@ -145,9 +145,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/DocumentLatestVersionError.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/DocumentLatestVersionError.html
@@ -153,9 +153,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/DocumentLocation.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/DocumentLocation.html
@@ -393,9 +393,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:47 2020 by
+  Generated on Thu Jun  4 18:14:23 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/DocumentMissingDependenciesError.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/DocumentMissingDependenciesError.html
@@ -302,9 +302,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/DocumentMissingModuleError.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/DocumentMissingModuleError.html
@@ -153,9 +153,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/DocumentResolutionErrorBase.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/DocumentResolutionErrorBase.html
@@ -372,9 +372,9 @@ a valid Puppetfile against a dependency resolution</p>
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/DocumentResolveError.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/DocumentResolveError.html
@@ -290,9 +290,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/DocumentValidationErrorBase.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/DocumentValidationErrorBase.html
@@ -401,9 +401,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/DocumentVersionConflictError.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/DocumentVersionConflictError.html
@@ -295,9 +295,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/ForgeModule.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/ForgeModule.html
@@ -211,9 +211,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/GitModule.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/GitModule.html
@@ -493,9 +493,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/InvalidModule.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/InvalidModule.html
@@ -289,9 +289,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/LocalModule.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/LocalModule.html
@@ -211,9 +211,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/Parser.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/Parser.html
@@ -109,9 +109,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:47 2020 by
+  Generated on Thu Jun  4 18:14:23 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/Parser/ParserError.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/Parser/ParserError.html
@@ -330,9 +330,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/Parser/R10KEval.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/Parser/R10KEval.html
@@ -278,9 +278,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:47 2020 by
+  Generated on Thu Jun  4 18:14:23 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/Parser/R10KEval/DSL.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/Parser/R10KEval/DSL.html
@@ -534,9 +534,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/Parser/R10KEval/Module.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/Parser/R10KEval/Module.html
@@ -109,9 +109,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:47 2020 by
+  Generated on Thu Jun  4 18:14:23 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/Parser/R10KEval/Module/Forge.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/Parser/R10KEval/Module/Forge.html
@@ -335,9 +335,9 @@ From Semantic Puppet gem</p>
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/Parser/R10KEval/Module/Git.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/Parser/R10KEval/Module/Git.html
@@ -252,9 +252,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:47 2020 by
+  Generated on Thu Jun  4 18:14:23 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/Parser/R10KEval/Module/Invalid.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/Parser/R10KEval/Module/Invalid.html
@@ -242,9 +242,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:47 2020 by
+  Generated on Thu Jun  4 18:14:23 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/Parser/R10KEval/Module/Local.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/Parser/R10KEval/Module/Local.html
@@ -260,9 +260,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/Parser/R10KEval/Module/Svn.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/Parser/R10KEval/Module/Svn.html
@@ -246,9 +246,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:47 2020 by
+  Generated on Thu Jun  4 18:14:23 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/Parser/R10KEval/PuppetModule.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/Parser/R10KEval/PuppetModule.html
@@ -238,9 +238,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:47 2020 by
+  Generated on Thu Jun  4 18:14:23 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Puppetfile/SvnModule.html
+++ b/docs/reference/PuppetfileResolver/Puppetfile/SvnModule.html
@@ -289,9 +289,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/ResolutionProvider.html
+++ b/docs/reference/PuppetfileResolver/ResolutionProvider.html
@@ -1029,9 +1029,9 @@ order, so the latest version ought to be last.</p>
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:48 2020 by
+  Generated on Thu Jun  4 18:14:24 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/ResolutionResult.html
+++ b/docs/reference/PuppetfileResolver/ResolutionResult.html
@@ -443,9 +443,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:47 2020 by
+  Generated on Thu Jun  4 18:14:23 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Resolver.html
+++ b/docs/reference/PuppetfileResolver/Resolver.html
@@ -462,9 +462,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:47 2020 by
+  Generated on Thu Jun  4 18:14:23 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/UI.html
+++ b/docs/reference/PuppetfileResolver/UI.html
@@ -107,9 +107,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:47 2020 by
+  Generated on Thu Jun  4 18:14:23 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/UI/DebugUI.html
+++ b/docs/reference/PuppetfileResolver/UI/DebugUI.html
@@ -208,9 +208,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:47 2020 by
+  Generated on Thu Jun  4 18:14:23 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/UI/NullUI.html
+++ b/docs/reference/PuppetfileResolver/UI/NullUI.html
@@ -271,9 +271,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:47 2020 by
+  Generated on Thu Jun  4 18:14:23 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/PuppetfileResolver/Util.html
+++ b/docs/reference/PuppetfileResolver/Util.html
@@ -236,9 +236,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:47 2020 by
+  Generated on Thu Jun  4 18:14:23 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/_index.html
+++ b/docs/reference/_index.html
@@ -525,9 +525,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:47 2020 by
+  Generated on Thu Jun  4 18:14:23 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/file.README.html
+++ b/docs/reference/file.README.html
@@ -60,7 +60,7 @@
       <div id="content"><div id='filecontents'><p><a href="https://travis-ci.com/glennsarti/puppetfile-resolver"><img src="https://travis-ci.com/glennsarti/puppetfile-resolver.svg?branch=master" alt="Build Status"></a>
 <a href="https://rubygems.org/gems/puppetfile-resolver"><img src="https://img.shields.io/gem/v/puppetfile-resolver" alt="Gem Version"></a></p>
 
-<h1>Puppetfile Resolver</h1>
+<h1 id="puppetfile-resolver">Puppetfile Resolver</h1>
 
 <p>The <a href="https://puppet.com/docs/pe/latest/puppetfile.html">Puppetfile</a> is used by Puppet to manage the collection of modules used by a Puppet master. The Puppetfile is then used by tools like <a href="https://github.com/puppetlabs/r10k">R10K</a> and <a href="https://puppet.com/docs/pe/latest/code_mgr_how_it_works.html#how-code-manager-works">Code Manager</a> to download and install the required modules.</p>
 
@@ -72,7 +72,7 @@
 
 <p><strong>Note</strong> This is still in active development. Git history may be re-written until an initial version is released</p>
 
-<h2>Documentation</h2>
+<h2 id="documentation">Documentation</h2>
 
 <ul>
 <li><a href="https://glennsarti.github.io/puppetfile-resolver/">About</a></li>
@@ -84,9 +84,9 @@
 </div></div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:47 2020 by
+  Generated on Thu Jun  4 18:14:23 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -60,7 +60,7 @@
       <div id="content"><div id='filecontents'><p><a href="https://travis-ci.com/glennsarti/puppetfile-resolver"><img src="https://travis-ci.com/glennsarti/puppetfile-resolver.svg?branch=master" alt="Build Status"></a>
 <a href="https://rubygems.org/gems/puppetfile-resolver"><img src="https://img.shields.io/gem/v/puppetfile-resolver" alt="Gem Version"></a></p>
 
-<h1>Puppetfile Resolver</h1>
+<h1 id="puppetfile-resolver">Puppetfile Resolver</h1>
 
 <p>The <a href="https://puppet.com/docs/pe/latest/puppetfile.html">Puppetfile</a> is used by Puppet to manage the collection of modules used by a Puppet master. The Puppetfile is then used by tools like <a href="https://github.com/puppetlabs/r10k">R10K</a> and <a href="https://puppet.com/docs/pe/latest/code_mgr_how_it_works.html#how-code-manager-works">Code Manager</a> to download and install the required modules.</p>
 
@@ -72,7 +72,7 @@
 
 <p><strong>Note</strong> This is still in active development. Git history may be re-written until an initial version is released</p>
 
-<h2>Documentation</h2>
+<h2 id="documentation">Documentation</h2>
 
 <ul>
 <li><a href="https://glennsarti.github.io/puppetfile-resolver/">About</a></li>
@@ -84,9 +84,9 @@
 </div></div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:47 2020 by
+  Generated on Thu Jun  4 18:14:23 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>

--- a/docs/reference/top-level-namespace.html
+++ b/docs/reference/top-level-namespace.html
@@ -100,9 +100,9 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Mar 20 14:31:47 2020 by
+  Generated on Thu Jun  4 18:14:23 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.24 (ruby-2.5.1).
+  0.9.25 (ruby-2.5.1).
 </div>
 
     </div>


### PR DESCRIPTION
Fixes #7 

There was a missing require in the example usage due to using bundle versus a
gem install.  This commit also updates the yard documentation.