### PR TITLE
(GH-10) Account for legacy style version requirement in module metadata

### DIFF
--- a/lib/puppetfile-resolver/models/module_specification.rb
+++ b/lib/puppetfile-resolver/models/module_specification.rb
@@ -90,7 +90,7 @@ module PuppetfileResolver
           @dependencies = meta[:dependencies].map do |dep|
             ModuleDependency.new(
               name: dep[:name],
-              version_requirement: dep[:version_requirement]
+              version_requirement: dep[:version_requirement] || dep[:version_range] || '>= 0.0.0'
             )
           end
         end


### PR DESCRIPTION
Fixes #10

Previously the resolver assumed that all module version requirements would be
specified using version_requirements [1]. However extremely old modules on the
Puppet Forge still use the old version_range parameter, for example PUP-2781 [2]

This commit updates the module specification parser to try the correct name,
then the old legacy name and then revert to an open dependency (>= 0).

This commit also adds tests for these scenarios

[1] https://puppet.com/docs/puppet/latest/modules_metadata.html#specifying-dependencies
[2] https://tickets.puppetlabs.com/browse/PUP-2781