### PR TITLE
Read Puppetfile document model from resolution result

### DIFF
--- a/lib/puppetfile-resolver/resolution_result.rb
+++ b/lib/puppetfile-resolver/resolution_result.rb
@@ -4,7 +4,7 @@ require 'molinillo'
 
 module PuppetfileResolver
   class ResolutionResult
-    attr_reader :dependency_graph
+    attr_reader :dependency_graph, :puppetfile_document
 
     def initialize(dependency_graph, puppetfile_document)
       raise "Expected Molinillo::DependencyGraph but got #{dependency_graph.class}" unless dependency_graph.is_a?(Molinillo::DependencyGraph)


### PR DESCRIPTION
This adds an attribute reader to the resolution result class that
returns the result's Puppetfile document model. Currently, the document
model is inaccessible, requiring you to build a new document model from
the specifications hash.

This change would be helpful for the work we are currently doing in Bolt,
as the workflow we are implementing includes both parsing an existing
Puppetfile and resolving module specs. We would like to be able to work
with the data from both parsing and resolving in the same manner, but
since the resolution result doesn't provide access to the document model
we need to build a new one from the specifications hash. This isn't a big
problem, but since the document model we need is already there, it'd be
nice to be able to access it.