### PR TITLE
Support version ranges when resolving dependencies

### DIFF
--- a/lib/puppetfile-resolver/puppetfile/parser/r10k_eval/module/forge.rb
+++ b/lib/puppetfile-resolver/puppetfile/parser/r10k_eval/module/forge.rb
@@ -14,7 +14,7 @@ module PuppetfileResolver
 
             def self.to_document_module(title, args)
               mod = ::PuppetfileResolver::Puppetfile::ForgeModule.new(title)
-              mod.version = args || :latest if valid_version?(args)
+              mod.version = munge_version_string(args) if valid_version?(args)
               mod
             end
 
@@ -42,6 +42,12 @@ module PuppetfileResolver
               end
             end
             private_class_method :valid_version_string?
+
+            def self.munge_version_string(value)
+              return :latest if value.nil? || value == :latest
+              "=#{value}"
+            end
+            private_class_method :munge_version_string
           end
         end
       end

--- a/lib/puppetfile-resolver/resolver.rb
+++ b/lib/puppetfile-resolver/resolver.rb
@@ -55,7 +55,7 @@ module PuppetfileResolver
         if mod.version.nil? || mod.version == :latest
           version = '>= 0' # Note the `>=` is important. Don't use `>`
         else
-          version = "=#{mod.version}"
+          version = mod.version
         end
 
         result << Models::PuppetfileDependency.new(

--- a/spec/unit/puppetfile-resolver/puppetfile/parser/r10k_eval_spec.rb
+++ b/spec/unit/puppetfile-resolver/puppetfile/parser/r10k_eval_spec.rb
@@ -64,7 +64,7 @@ RSpec.shared_examples "a puppetfile parser with valid content" do
       expect(mod.title).to eq('puppetlabs-forge_fixed_ver')
       expect(mod.owner).to eq('puppetlabs')
       expect(mod.name).to eq('forge_fixed_ver')
-      expect(mod.version).to eq('1.0.0')
+      expect(mod.version).to eq('=1.0.0')
       expect(mod.location.start_line).to eq(2)
       expect(mod.location.start_char).to be_nil
       expect(mod.location.end_line).to eq(2)


### PR DESCRIPTION
This change adds support for using version ranges for module
definitions. Currently, module definitions are restricted to using a
specific semantic version, or using versioning shorthand, as the
resolver sets the version to `=#{mod.version}`. If a module has a
version range, this results in an unparsable version (e.g. `=>=1.0.0 <
3.0.0`).