### PR TITLE
Add support for alternate Forge and proxies

### DIFF
--- a/lib/puppetfile-resolver/resolver.rb
+++ b/lib/puppetfile-resolver/resolver.rb
@@ -21,6 +21,9 @@ module PuppetfileResolver
     # options
     #   :cache => Cache Object
     #   :module_paths => Array[String]
+    #   :forge_api_url => String
+    #   :forge_proxy => String
+    #   :proxy => String
     def resolve(options = {})
       if options[:ui]
         raise 'The UI object must be of type Molinillo::UI' unless options[:ui].is_a?(Molinillo::UI)

--- a/lib/puppetfile-resolver/spec_searchers/git.rb
+++ b/lib/puppetfile-resolver/spec_searchers/git.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
+require 'puppetfile-resolver/util'
 require 'puppetfile-resolver/spec_searchers/common'
 
 module PuppetfileResolver
   module SpecSearchers
     module Git
-      def self.find_all(puppetfile_module, dependency, cache, resolver_ui)
+      def self.find_all(puppetfile_module, dependency, cache, proxy, resolver_ui)
         dep_id = ::PuppetfileResolver::SpecSearchers::Common.dependency_cache_id(self, dependency)
         # Has the information been cached?
         return cache.load(dep_id) if cache.exist?(dep_id)
@@ -39,8 +40,20 @@ module PuppetfileResolver
         require 'net/http'
         require 'uri'
 
-        resolver_ui.debug { "Querying the Github with #{metadata_url}" }
-        response = Net::HTTP.get_response(URI.parse(metadata_url))
+        resolver_ui.debug { "Querying GitHub with #{metadata_url}" }
+        response = nil
+
+        begin
+          ::PuppetfileResolver::Util.with_proxy_envvars(proxy) do
+            response = Net::HTTP.get_response(URI.parse(metadata_url))
+          end
+        rescue SocketError => e
+          msg = "Unable to find module at #{puppetfile_module.remote}"
+          msg += proxy ? " with proxy #{proxy}: " : ": "
+          msg += e.message
+          raise msg
+        end
+
         if response.code != '200'
           cache.save(dep_id, [])
           return []

--- a/lib/puppetfile-resolver/util.rb
+++ b/lib/puppetfile-resolver/util.rb
@@ -2,6 +2,12 @@
 
 module PuppetfileResolver
   module Util
+    PROXY_ENVVARS = if File::ALT_SEPARATOR
+                      %w[https_proxy http_proxy].freeze
+                    else
+                      %w[HTTPS_PROXY HTTP_PROXY https_proxy http_proxy].freeze
+                    end
+
     def self.symbolise_object(object)
       case # rubocop:disable Style/EmptyCaseCondition Ignore
       when object.is_a?(Hash)
@@ -18,6 +24,22 @@ module PuppetfileResolver
 
     def self.static_ca_cert_file
       @static_ca_cert_file ||= File.expand_path(File.join(__dir__, 'data', 'ruby_ca_certs.pem'))
+    end
+
+    # Executes the block with the given proxy set in ENV.
+    def self.with_proxy_envvars(new_proxy)
+      unless new_proxy.nil?
+        old_proxy = Hash[PROXY_ENVVARS.collect { |var| [var, ENV[var]] }]
+        old_proxy.each_key { |var| ENV[var] = new_proxy }
+      end
+
+      begin
+        yield
+      ensure
+        ENV.update(old_proxy) if old_proxy
+      end
+
+      nil
     end
   end
 end


### PR DESCRIPTION
This adds a few new options for the resolver:

- `forge_api_url`: Set the URL to an alternate Forge
- `forge_proxy`: The HTTP proxy to use for Forge operations
- `proxy`: The HTTP proxy to use for Git and Forge operations

This allows users to resolve modules from a Forge other than the
public-facing Puppet Forge, and to use HTTP proxies when making requests
to GitHub and the Forge.