### PR TITLE
(GH-22) Add a formal config system for spec searchers

### DIFF
--- a/lib/puppetfile-resolver/resolver.rb
+++ b/lib/puppetfile-resolver/resolver.rb
@@ -20,7 +20,8 @@ module PuppetfileResolver
 
     # options
     #   :cache => Cache Object
-    #   :module_paths => Array[String]
+    #   :module_paths => Array[String] (Deprecated)
+    #   :spec_searcher_configuration => PuppetfileResolver::SpecSearchers::Configuration
     def resolve(options = {})
       if options[:ui]
         raise 'The UI object must be of type Molinillo::UI' unless options[:ui].is_a?(Molinillo::UI)

--- a/lib/puppetfile-resolver/spec_searchers/configuration.rb
+++ b/lib/puppetfile-resolver/spec_searchers/configuration.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'puppetfile-resolver/spec_searchers/forge_configuration'
+require 'puppetfile-resolver/spec_searchers/git_configuration'
+require 'puppetfile-resolver/spec_searchers/local_configuration'
+
+module PuppetfileResolver
+  module SpecSearchers
+    class Configuration
+      attr_reader :local
+      attr_reader :forge
+      attr_reader :git
+
+      def initialize
+        @local = LocalConfiguration.new
+        @forge = ForgeConfiguration.new
+        @git = GitConfiguration.new
+      end
+    end
+  end
+end

--- a/lib/puppetfile-resolver/spec_searchers/forge_configuration.rb
+++ b/lib/puppetfile-resolver/spec_searchers/forge_configuration.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PuppetfileResolver
+  module SpecSearchers
+    class ForgeConfiguration
+      DEFAULT_FORGE_URI ||= 'https://forgeapi.puppet.com'
+
+      def forge_api
+        @forge_api || DEFAULT_FORGE_URI
+      end
+
+      attr_writer :forge_api
+    end
+  end
+end

--- a/lib/puppetfile-resolver/spec_searchers/git.rb
+++ b/lib/puppetfile-resolver/spec_searchers/git.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 require 'puppetfile-resolver/spec_searchers/common'
+require 'puppetfile-resolver/spec_searchers/git_configuration'
 
 module PuppetfileResolver
   module SpecSearchers
     module Git
-      def self.find_all(puppetfile_module, dependency, cache, resolver_ui)
+      def self.find_all(puppetfile_module, dependency, cache, resolver_ui, _config)
         dep_id = ::PuppetfileResolver::SpecSearchers::Common.dependency_cache_id(self, dependency)
         # Has the information been cached?
         return cache.load(dep_id) if cache.exist?(dep_id)

--- a/lib/puppetfile-resolver/spec_searchers/git_configuration.rb
+++ b/lib/puppetfile-resolver/spec_searchers/git_configuration.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module PuppetfileResolver
+  module SpecSearchers
+    class GitConfiguration
+    end
+  end
+end

--- a/lib/puppetfile-resolver/spec_searchers/local.rb
+++ b/lib/puppetfile-resolver/spec_searchers/local.rb
@@ -1,18 +1,19 @@
 # frozen_string_literal: true
 
 require 'puppetfile-resolver/spec_searchers/common'
+require 'puppetfile-resolver/spec_searchers/local_configuration'
 
 module PuppetfileResolver
   module SpecSearchers
     module Local
-      def self.find_all(_puppetfile_module, puppet_module_paths, dependency, cache, resolver_ui)
+      def self.find_all(_puppetfile_module, dependency, cache, resolver_ui, config)
         dep_id = ::PuppetfileResolver::SpecSearchers::Common.dependency_cache_id(self, dependency)
         # Has the information been cached?
         return cache.load(dep_id) if cache.exist?(dep_id)
 
         result = []
         # Find the module in the modulepaths
-        puppet_module_paths.each do |module_path|
+        config.puppet_module_paths.each do |module_path|
           next unless Dir.exist?(module_path)
           module_dir = File.expand_path(File.join(module_path, dependency.name))
           next unless Dir.exist?(module_dir)

--- a/lib/puppetfile-resolver/spec_searchers/local_configuration.rb
+++ b/lib/puppetfile-resolver/spec_searchers/local_configuration.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module PuppetfileResolver
+  module SpecSearchers
+    class LocalConfiguration
+      attr_accessor :puppet_module_paths
+
+      def initialize
+        @puppet_module_paths = []
+      end
+    end
+  end
+end

--- a/puppetfile-cli.rb
+++ b/puppetfile-cli.rb
@@ -88,7 +88,11 @@ if options[:debug]
 else
   ui = nil
 end
-opts = { cache: cache, ui: ui, module_paths: options[:module_paths], allow_missing_modules: !options[:strict] }
+
+config = PuppetfileResolver::SpecSearchers::Configuration.new
+config.local.puppet_module_paths = options[:module_paths]
+
+opts = { cache: cache, ui: ui, spec_searcher_configuration: config, allow_missing_modules: !options[:strict] }
 
 # Resolve
 result = resolver.resolve(opts)

--- a/spec/fixtures/modulepath/test_module/README.md
+++ b/spec/fixtures/modulepath/test_module/README.md
@@ -1,0 +1,1 @@
+This test fixture contains a valid module with classes, types and functions.

--- a/spec/fixtures/modulepath/test_module/metadata.json
+++ b/spec/fixtures/modulepath/test_module/metadata.json
@@ -1,0 +1,9 @@
+{
+  "name": "testfixture-test_module",
+  "version": "0.1.0",
+  "author": "testfixture",
+  "summary": "Skeleton module test fixture",
+  "license": "Apache-2.0",
+  "source": "http://localhost",
+  "dependencies": []
+}

--- a/spec/integration/deprecation_spec.rb
+++ b/spec/integration/deprecation_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+require 'puppetfile-resolver/resolver'
+require 'puppetfile-resolver/puppetfile'
+
+
+describe 'Depreaction Tests' do
+  context 'With module_paths option' do
+    it 'should resolve a complete Puppetfile' do
+
+      content = <<-PUPFILE
+      forge 'https://forge.puppet.com'
+
+      # Local module path module
+      mod 'testfixture/test_module', :latest
+      PUPFILE
+
+      puppetfile = ::PuppetfileResolver::Puppetfile::Parser::R10KEval.parse(content)
+      resolver = PuppetfileResolver::Resolver.new(puppetfile)
+
+      expect(Warning).to receive(:warn).with(/module_paths/).and_return(nil)
+
+      result = resolver.resolve({
+        allow_missing_modules: false,
+        module_paths: [File.join(FIXTURES_DIR, 'modulepath')]
+      })
+
+      expect(result.specifications).to include('test_module')
+      expect(result.specifications['test_module'].version.to_s).to eq('0.1.0')
+    end
+  end
+end

--- a/spec/integration/kitchensink_spec.rb
+++ b/spec/integration/kitchensink_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+require 'puppetfile-resolver/resolver'
+require 'puppetfile-resolver/puppetfile'
+
+
+describe 'KitchenSink Tests' do
+  it 'should resolve a complete Puppetfile' do
+
+    content = <<-PUPFILE
+    forge 'https://forge.puppet.com'
+
+    mod 'powershell',
+      :git => 'https://github.com/puppetlabs/puppetlabs-powershell',
+      :tag => 'v4.0.0'
+
+    mod 'puppetlabs/stdlib', '6.3.0'
+
+    # Local module path module
+    mod 'testfixture/test_module', :latest
+
+    PUPFILE
+
+    puppetfile = ::PuppetfileResolver::Puppetfile::Parser::R10KEval.parse(content)
+
+    config = PuppetfileResolver::SpecSearchers::Configuration.new
+    config.local.puppet_module_paths = [File.join(FIXTURES_DIR, 'modulepath')]
+
+    resolver = PuppetfileResolver::Resolver.new(puppetfile)
+    result = resolver.resolve({
+      allow_missing_modules: false,
+      spec_searcher_configuration: config,
+    })
+
+    expect(result.specifications).to include('powershell')
+    expect(result.specifications['powershell'].version.to_s).to eq('4.0.0')
+
+    expect(result.specifications).to include('stdlib')
+    expect(result.specifications['stdlib'].version.to_s).to eq('6.3.0')
+
+    expect(result.specifications).to include('test_module')
+    expect(result.specifications['test_module'].version.to_s).to eq('0.1.0')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ root = File.join(__dir__,'..',)
 # Add the language server into the load path
 $LOAD_PATH.unshift(File.join(root,'lib'))
 
+FIXTURES_DIR = File.join(__dir__,'fixtures')
+
 # A cache which we can preload for the purposes of testing, mimicing
 # Local modules
 require 'puppetfile-resolver/cache/base'

--- a/spec/unit/puppetfile-resolver/resolver_spec.rb
+++ b/spec/unit/puppetfile-resolver/resolver_spec.rb
@@ -7,7 +7,7 @@ describe PuppetfileResolver::Resolver do
   let(:puppet_version) { nil }
   let(:subject) { PuppetfileResolver::Resolver.new(puppetfile_document, puppet_version) }
   let(:cache) { MockLocalModuleCache.new }
-  let(:default_resolve_options) { { cache: cache, module_paths: ['??does/not/exist'] } }
+  let(:default_resolve_options) { { cache: cache } }
   let(:resolve_options) { default_resolve_options }
 
   RSpec.shared_examples 'a resolver flag' do |flag|


### PR DESCRIPTION
Fixes #22 

Currently you can't pass in options to the spec searchers. Need to make a formal config system

Previously users could not pass in options/configuration information into the
spec searchers.  This commit adds a formal object system to pass in information
into the spec searchers and deprecates the use of the module_paths resolver
option.

This commit also adds some kitchen sink and deprecated tests to ensure that the
resolver actually resolves modules from _actual_ sources.