### PR TITLE
(maint) Drop support for Ruby 2.1 (Puppet 4)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
   - 'bundle exec $CHECK'
 bundler_args: --without system_tests
 rvm:
-  - 2.5.3
+  - 2.7.2
 stages:
   - spec
 matrix:
@@ -27,7 +27,7 @@ matrix:
     -
       env: CHECK="rspec" RUBYGEMS_VERSION=2.7.8
       stage: spec
-      rvm: 2.1.9
+      rvm: 2.5.3
 
 branches:
   only:

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :development do
     gem "rubocop", "<= 0.57.2", :require => false, :platforms => [:ruby, :x64_mingw]
     gem 'rake', '~> 12.3',      :require => false
   else
-    gem "rubocop", ">= 0.80.1", :require => false, :platforms => [:ruby, :x64_mingw]
+    gem "rubocop", "~> 0.80", :require => false, :platforms => [:ruby, :x64_mingw]
     gem 'rake', '>= 10.4',      :require => false
   end
 

--- a/puppetfile-resolver.gemspec
+++ b/puppetfile-resolver.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.1.9'
+  spec.required_ruby_version = '>= 2.5.3'
 
   spec.add_runtime_dependency 'molinillo', '~> 0.6'
   spec.add_runtime_dependency 'semantic_puppet', '~> 1.0'


### PR DESCRIPTION
This commit removes Ruby 2.1 from the supported ruby versions and updates
testing to use the latest ruby version supported by Puppet Agent