### PR TITLE
Add support for HTTP proxies

### DIFF
--- a/lib/puppetfile-resolver/spec_searchers/forge_configuration.rb
+++ b/lib/puppetfile-resolver/spec_searchers/forge_configuration.rb
@@ -10,6 +10,8 @@ module PuppetfileResolver
       end
 
       attr_writer :forge_api
+
+      attr_accessor :proxy
     end
   end
 end

--- a/lib/puppetfile-resolver/spec_searchers/git_configuration.rb
+++ b/lib/puppetfile-resolver/spec_searchers/git_configuration.rb
@@ -3,6 +3,7 @@
 module PuppetfileResolver
   module SpecSearchers
     class GitConfiguration
+      attr_accessor :proxy
     end
   end
 end

--- a/lib/puppetfile-resolver/util.rb
+++ b/lib/puppetfile-resolver/util.rb
@@ -19,5 +19,29 @@ module PuppetfileResolver
     def self.static_ca_cert_file
       @static_ca_cert_file ||= File.expand_path(File.join(__dir__, 'data', 'ruby_ca_certs.pem'))
     end
+
+    # Execute a HTTP/S GET query and return the response
+    # @param [String, URI] uri The URI to request
+    # @param [nil, String, URI] proxy The URI of the proxy server to use. Defaults to nil (No proxy server)
+    # @return [Net::HTTPResponse] the response of the request
+    def self.net_http_get(uri, proxy = nil)
+      uri = URI.parse(uri) unless uri.is_a?(URI)
+
+      http_options = { :use_ssl => uri.class == URI::HTTPS }
+      # Because on Windows Ruby doesn't use the Windows certificate store which has up-to date
+      # CA certs, we can't depend on someone setting the environment variable correctly. So use our
+      # static CA PEM file if SSL_CERT_FILE is not set.
+      http_options[:ca_file] = PuppetfileResolver::Util.static_ca_cert_file if ENV['SSL_CERT_FILE'].nil?
+
+      start_args = [uri.host, uri.port]
+
+      unless proxy.nil?
+        proxy = URI.parse(proxy) unless proxy.is_a?(URI)
+        start_args.concat([proxy.host, proxy.port, proxy.user, proxy.password])
+      end
+
+      Net::HTTP.start(*start_args, http_options) { |http| return http.request(Net::HTTP::Get.new(uri)) }
+      nil
+    end
   end
 end

--- a/puppetfile-cli.rb
+++ b/puppetfile-cli.rb
@@ -18,6 +18,7 @@ class CommandLineParser
       cache_dir: nil,
       module_paths: [],
       path: nil,
+      proxy: nil,
       puppet_version: nil,
       strict: false
     }
@@ -39,6 +40,10 @@ class CommandLineParser
 
       opts.on('--debug', 'Output debug information. Default is no debug output') do
         args[:debug] = true
+      end
+
+      opts.on('--proxy=PROXY_URL', 'HTTP/S Proxy server to use. For example http://localhost:8888') do |proxy|
+        args[:proxy] = proxy
       end
 
       opts.on('-s', '--strict', 'Do not allow missing dependencies. Default false which marks dependencies as missing and does not raise an error.') do
@@ -91,6 +96,10 @@ end
 
 config = PuppetfileResolver::SpecSearchers::Configuration.new
 config.local.puppet_module_paths = options[:module_paths]
+unless options[:proxy].nil?
+  config.git.proxy = options[:proxy]
+  config.forge.proxy = options[:proxy]
+end
 
 opts = { cache: cache, ui: ui, spec_searcher_configuration: config, allow_missing_modules: !options[:strict] }
 

--- a/spec/fixtures/proxy.rb
+++ b/spec/fixtures/proxy.rb
@@ -1,0 +1,9 @@
+require 'webrick'
+require 'webrick/httpproxy'
+
+proxy = WEBrick::HTTPProxyServer.new Port: (ARGV[0].nil? ? 32768 : ARGV[0])
+
+trap 'INT'  do proxy.shutdown end
+trap 'TERM' do proxy.shutdown end
+
+proxy.start

--- a/spec/integration/proxy_spec.rb
+++ b/spec/integration/proxy_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+require 'open3'
+require 'puppetfile-resolver/resolver'
+require 'puppetfile-resolver/puppetfile'
+
+describe 'Proxy Tests' do
+  let(:content) do <<-PUPFILE
+    forge 'https://forge.puppet.com'
+
+    mod 'powershell',
+      :git => 'https://github.com/puppetlabs/puppetlabs-powershell',
+      :tag => 'v4.0.0'
+
+    mod 'puppetlabs/stdlib', '6.3.0'
+    PUPFILE
+  end
+  let(:puppetfile) { ::PuppetfileResolver::Puppetfile::Parser::R10KEval.parse(content) }
+  let(:resolver_config) do
+    PuppetfileResolver::SpecSearchers::Configuration.new.tap do |obj|
+      obj.git.proxy = 'http://localhost:32768'
+      obj.forge.proxy = 'http://localhost:32768'
+    end
+  end
+
+  context 'with an invalid proxy server' do
+    it 'should not resolve a complete Puppetfile' do
+      resolver = PuppetfileResolver::Resolver.new(puppetfile)
+      result = resolver.resolve({
+        allow_missing_modules: true,
+        spec_searcher_configuration: resolver_config,
+      })
+
+      expect(result.specifications).to include('powershell')
+      expect(result.specifications['powershell']).to be_a(PuppetfileResolver::Models::MissingModuleSpecification)
+
+      expect(result.specifications).to include('stdlib')
+      expect(result.specifications['stdlib']).to be_a(PuppetfileResolver::Models::MissingModuleSpecification)
+    end
+  end
+
+  context 'with a valid proxy server' do
+    def start_proxy_server(start_options = ['--timeout=5'])
+      cmd = "ruby \"#{File.join(FIXTURES_DIR, 'proxy.rb')}\" 32768"
+
+      stdin, stdout, stderr, wait_thr = Open3.popen3(cmd)
+      # Wait for the Proxy server to indicate it started
+      line = nil
+      begin
+        line = stderr.readline
+      end until line =~ /#start/
+      stdout.close
+      stdin.close
+      [wait_thr, stderr]
+    end
+
+    before(:each) do
+      @server_thr, @server_pipe = start_proxy_server
+    end
+
+    after(:each) do
+      begin
+        Process.kill("KILL", @server_thr[:pid])
+        Process.wait(@server_thr[:pid])
+      rescue
+        # The server process may not exist and checking in a cross platform way in ruby is difficult
+        # Instead just swallow any errors
+      end
+
+      begin
+        @server_pipe.close
+      rescue
+        # The server process may not exist and checking in a cross platform way in ruby is difficult
+        # Instead just swallow any errors
+      end
+    end
+
+    it 'should resolve a complete Puppetfile' do
+      resolver = PuppetfileResolver::Resolver.new(puppetfile)
+      result = resolver.resolve({
+        allow_missing_modules: false,
+        spec_searcher_configuration: resolver_config,
+      })
+
+      expect(result.specifications).to include('powershell')
+      expect(result.specifications['powershell'].version.to_s).to eq('4.0.0')
+
+      expect(result.specifications).to include('stdlib')
+      expect(result.specifications['stdlib'].version.to_s).to eq('6.3.0')
+    end
+  end
+end


### PR DESCRIPTION
This adds a few new configuration options to the searchers

- `git.proxy`: URL for the proxy to Git based requests
- `forge.proxy`: URL for the proxy to Forge requests

This allows users to use HTTP proxies when making requests to GitHub and the
Forge. Note that the HTTPS_PROXY and HTTP_PROXY environment variables are still
viable options to set a HTTTP/S proxy.