### PR TITLE
(GH-29) Add support for GitLab URLs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ Note that a CLI is included (`puppetfile-cli.rb`) only as an example of how to c
 
 ``` text
                     +-----------------+   +-----------------+   +-----------------+
-                    | Forge Searcher  |   | Github Searcher |   | Local Searcher  |
+                    | Forge Searcher  |   |  Git Searcher   |   | Local Searcher  |
                     +-------+---------+   +--------+--------+   +-------+---------+
                             |                      |                    |
                             +----------------------+--------------------+
@@ -92,7 +92,7 @@ Given a Puppetfile document model, the library can attempt to recursively resolv
 
 ### Module Searchers
 
-The Puppetfile resolution needs information about all of the available modules and versions, and does this through calling various Specification Searchers. Currently Puppet Forge, Github and Local FileSystem searchers are implemented. Additional searchers could be added, for example GitLab or SVN.
+The Puppetfile resolution needs information about all of the available modules and versions, and does this through calling various Specification Searchers. Currently Puppet Forge, GitHub, GitLab and Local FileSystem searchers are implemented. Additional searchers could be added, for example SVN.
 
 The result is a dependency graph listing all of the modules, dependencies and version information.
 

--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -9,4 +9,4 @@
 
 - The Forge module searcher will only use the internet facing forge ([https://forge.puppet.com](https://forge.puppet.com/)). Self-hosted forges are not supported
 
-- The Git module searcher will only search public Github based modules. Private repositories or other VCS systems are not supported
+- The Git module searcher will only search public GitHub and GitLab based modules. Private repositories or other VCS systems are not supported

--- a/lib/puppetfile-resolver/spec_searchers/git.rb
+++ b/lib/puppetfile-resolver/spec_searchers/git.rb
@@ -3,6 +3,8 @@
 require 'puppetfile-resolver/util'
 require 'puppetfile-resolver/spec_searchers/common'
 require 'puppetfile-resolver/spec_searchers/git_configuration'
+require 'puppetfile-resolver/spec_searchers/git/github'
+require 'puppetfile-resolver/spec_searchers/git/gitlab'
 
 module PuppetfileResolver
   module SpecSearchers
@@ -14,52 +16,18 @@ module PuppetfileResolver
 
         # We _could_ git clone this, but it'll take too long. So for now, just
         # try and resolve github based repositories by crafting a URL
+        metadata = GitHub.metadata(puppetfile_module, resolver_ui, config)
+        metadata = GitLab.metadata(puppetfile_module, resolver_ui, config) if metadata.nil?
 
-        repo_url = nil
-        if puppetfile_module.remote.start_with?('git@github.com:')
-          repo_url = puppetfile_module.remote.slice(15..-1)
-          repo_url = repo_url.slice(0..-5) if repo_url.end_with?('.git')
-        end
-        if puppetfile_module.remote.start_with?('https://github.com/')
-          repo_url = puppetfile_module.remote.slice(19..-1)
-          repo_url = repo_url.slice(0..-5) if repo_url.end_with?('.git')
-        end
+        # TODO: Once we've exhausted using alternate methods lets just `git clone` it
 
-        return [] if repo_url.nil?
-
-        metadata_url = 'https://raw.githubusercontent.com/' + repo_url + '/'
-        if puppetfile_module.ref
-          metadata_url += puppetfile_module.ref + '/'
-        elsif puppetfile_module.tag
-          metadata_url += puppetfile_module.tag + '/'
-        else
-          # Default to master.  Should it raise?
-          metadata_url += 'master/'
-        end
-        metadata_url += 'metadata.json'
-
-        require 'net/http'
-        require 'uri'
-
-        resolver_ui.debug { "Querying GitHub with #{metadata_url}" }
-        err_msg = "Unable to find module at #{puppetfile_module.remote}"
-        err_msg += config.proxy ? " with proxy #{config.proxy}: " : ': '
-        response = nil
-
-        begin
-          response = ::PuppetfileResolver::Util.net_http_get(metadata_url, config.proxy)
-        rescue ::StandardError => e
-          raise err_msg + e.message
-        end
-
-        if response.code != '200'
-          resolver_ui.debug(err_msg + "Expected HTTP Code 200, but received #{response.code}")
+        if metadata.nil? || metadata.empty?
+          # Cache that we couldn't find the metadata
           cache.save(dep_id, [])
           return []
         end
 
-        # TODO: symbolise_object should be in a Util namespace
-        metadata = ::PuppetfileResolver::Util.symbolise_object(::JSON.parse(response.body))
+        metadata = ::PuppetfileResolver::Util.symbolise_object(::JSON.parse(metadata))
         result = [Models::ModuleSpecification.new(
           name: metadata[:name],
           origin: :git,

--- a/lib/puppetfile-resolver/spec_searchers/git/github.rb
+++ b/lib/puppetfile-resolver/spec_searchers/git/github.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'puppetfile-resolver/util'
+require 'puppetfile-resolver/spec_searchers/common'
+require 'puppetfile-resolver/spec_searchers/git_configuration'
+
+module PuppetfileResolver
+  module SpecSearchers
+    module Git
+      module GitHub
+        def self.metadata(puppetfile_module, resolver_ui, config)
+          repo_url = nil
+          if puppetfile_module.remote.start_with?('git@github.com:')
+            repo_url = puppetfile_module.remote.slice(15..-1)
+            repo_url = repo_url.slice(0..-5) if repo_url.end_with?('.git')
+          elsif puppetfile_module.remote.start_with?('https://github.com/')
+            repo_url = puppetfile_module.remote.slice(19..-1)
+            repo_url = repo_url.slice(0..-5) if repo_url.end_with?('.git')
+          end
+          return nil if repo_url.nil?
+
+          metadata_url = 'https://raw.githubusercontent.com/' + repo_url + '/'
+          if puppetfile_module.ref
+            metadata_url += puppetfile_module.ref + '/'
+          elsif puppetfile_module.tag
+            metadata_url += puppetfile_module.tag + '/'
+          else
+            # Default to master. Should it raise?
+            metadata_url += 'master/'
+          end
+          metadata_url += 'metadata.json'
+
+          resolver_ui.debug { "Querying GitHub with #{metadata_url}" }
+          err_msg = "Unable to find module at #{puppetfile_module.remote}"
+          err_msg += config.proxy ? " with proxy #{config.proxy}: " : ': '
+          response = nil
+
+          begin
+            response = ::PuppetfileResolver::Util.net_http_get(metadata_url, config.proxy)
+          rescue ::StandardError => e
+            raise err_msg + e.message
+          end
+
+          if response.code != '200'
+            resolver_ui.debug(err_msg + "Expected HTTP Code 200, but received #{response.code}")
+            return ''
+          end
+          response.body
+        end
+      end
+    end
+  end
+end

--- a/lib/puppetfile-resolver/spec_searchers/git/gitlab.rb
+++ b/lib/puppetfile-resolver/spec_searchers/git/gitlab.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'puppetfile-resolver/util'
+require 'puppetfile-resolver/spec_searchers/common'
+require 'puppetfile-resolver/spec_searchers/git_configuration'
+
+module PuppetfileResolver
+  module SpecSearchers
+    module Git
+      module GitLab
+        def self.metadata(puppetfile_module, resolver_ui, config)
+          repo_url = nil
+          if puppetfile_module.remote.start_with?('git@gitlab.com:')
+            repo_url = puppetfile_module.remote.slice(15..-1)
+            repo_url = repo_url.slice(0..-5) if repo_url.end_with?('.git')
+          elsif puppetfile_module.remote.start_with?('https://gitlab.com/')
+            repo_url = puppetfile_module.remote.slice(19..-1)
+            repo_url = repo_url.slice(0..-5) if repo_url.end_with?('.git')
+          end
+          return nil if repo_url.nil?
+
+          # Example URL
+          # https://gitlab.com/simp/pupmod-simp-crypto_policy/-/raw/0.1.4/metadata.json
+          metadata_url = 'https://gitlab.com/' + repo_url + '/-/raw/'
+          if puppetfile_module.ref
+            metadata_url += puppetfile_module.ref + '/'
+          elsif puppetfile_module.tag
+            metadata_url += puppetfile_module.tag + '/'
+          else
+            # Default to master. Should it raise?
+            metadata_url += 'master/'
+          end
+          metadata_url += 'metadata.json'
+
+          resolver_ui.debug { "Querying GitLab with #{metadata_url}" }
+          err_msg = "Unable to find module at #{puppetfile_module.remote}"
+          err_msg += config.proxy ? " with proxy #{config.proxy}: " : ': '
+          response = nil
+
+          begin
+            response = ::PuppetfileResolver::Util.net_http_get(metadata_url, config.proxy)
+          rescue ::StandardError => e
+            raise err_msg + e.message
+          end
+
+          if response.code != '200'
+            resolver_ui.debug(err_msg + "Expected HTTP Code 200, but received #{response.code}")
+            return ''
+          end
+          response.body
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/kitchensink_spec.rb
+++ b/spec/integration/kitchensink_spec.rb
@@ -3,16 +3,18 @@ require 'spec_helper'
 require 'puppetfile-resolver/resolver'
 require 'puppetfile-resolver/puppetfile'
 
-
 describe 'KitchenSink Tests' do
   it 'should resolve a complete Puppetfile' do
-
     content = <<-PUPFILE
     forge 'https://forge.puppet.com'
 
     mod 'powershell',
       :git => 'https://github.com/puppetlabs/puppetlabs-powershell',
       :tag => 'v4.0.0'
+
+    mod 'simpkv',
+      :git => 'https://gitlab.com/simp/pupmod-simp-simpkv.git',
+      :tag => '0.7.1'
 
     mod 'puppetlabs/stdlib', '6.3.0'
 
@@ -34,6 +36,9 @@ describe 'KitchenSink Tests' do
 
     expect(result.specifications).to include('powershell')
     expect(result.specifications['powershell'].version.to_s).to eq('4.0.0')
+
+    expect(result.specifications).to include('simpkv')
+    expect(result.specifications['simpkv'].version.to_s).to eq('0.7.1')
 
     expect(result.specifications).to include('stdlib')
     expect(result.specifications['stdlib'].version.to_s).to eq('6.3.0')


### PR DESCRIPTION
Fixes #29 

Previously the Git searcher only support public GitHub projects. This commit
also adds support for GitLab public repositories and makes it easier to add
different methods in the future.