### PR TITLE
Adds git clone method to search for metadata file 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 
 group :development do
   gem 'rspec', '>= 3.2', :require => false
-
+  gem 'pry'
   if RUBY_VERSION =~ /^2\.1\./
     gem "rubocop", "<= 0.57.2", :require => false, :platforms => [:ruby, :x64_mingw]
     gem 'rake', '~> 12.3',      :require => false

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,11 +18,11 @@ Note that a CLI is included (`puppetfile-cli.rb`) only as an example of how to c
 ## Architecture
 
 ``` text
-                    +-----------------+   +-----------------+   +-----------------+
-                    | Forge Searcher  |   |  Git Searcher   |   | Local Searcher  |
-                    +-------+---------+   +--------+--------+   +-------+---------+
-                            |                      |                    |
-                            +----------------------+--------------------+
+                    +-----------------+   +-----------------+   +-----------------+   +---------------------+
+                    | Forge Searcher  |   |  Git Searcher   |   | Local Searcher  |   | Other searchers.... |
+                    +-------+---------+   +--------+--------+   +-------+---------+   +----------+----------+
+                            |                      |                    |                        |
+                            +----------------------+--------------------+------------------------+---- ...
                                                    |
                                                    |
                                                    V
@@ -81,7 +81,6 @@ module_list.each do |mod_name|
 end
 ```
 
-
 ### Puppetfile Document Validation
 
 Even though a Puppetfile can be parsed, doesn't mean it's valid. For example, defining a module twice.
@@ -92,7 +91,7 @@ Given a Puppetfile document model, the library can attempt to recursively resolv
 
 ### Module Searchers
 
-The Puppetfile resolution needs information about all of the available modules and versions, and does this through calling various Specification Searchers. Currently Puppet Forge, GitHub, GitLab and Local FileSystem searchers are implemented. Additional searchers could be added, for example SVN.
+The Puppetfile resolution needs information about all of the available modules and versions, and does this through calling various Specification Searchers. Currently Puppet Forge, GitHub, GitLab, Git Clone and Local FileSystem searchers are implemented. Additional searchers could be added, for example SVN.
 
 The result is a dependency graph listing all of the modules, dependencies and version information.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,18 @@ This library includes all of the code to parse a Puppetfile and then calculate a
 
 **Note** This library is in active development!
 
+## Supported Searchers
+
+See "Module Searchers" in the [Architecture](./architecture) for more information about searchers.
+
+Currently supported searchers:
+
+* Git Clone
+* GitHub
+* GitLab
+* Local FileSystem
+* Puppet Forge
+
 ## To Do
 
 - Could do with more tests

--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -8,5 +8,3 @@
 ---
 
 - The Forge module searcher will only use the internet facing forge ([https://forge.puppet.com](https://forge.puppet.com/)). Self-hosted forges are not supported
-
-- The Git module searcher will only search public GitHub and GitLab based modules. Private repositories or other VCS systems are not supported

--- a/lib/puppetfile-resolver/spec_searchers/git/gclone.rb
+++ b/lib/puppetfile-resolver/spec_searchers/git/gclone.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'tempfile'
+require 'English'
+require 'puppetfile-resolver/util'
+require 'puppetfile-resolver/spec_searchers/common'
+require 'puppetfile-resolver/spec_searchers/git_configuration'
+require 'puppetfile-resolver/util'
+require 'uri'
+
+module PuppetfileResolver
+  module SpecSearchers
+    module Git
+      module GClone
+        # @summary clones the remote url and reads the metadata file
+        # @returns [String] the content of the metadata file
+        def self.metadata(puppetfile_module, resolver_ui, config)
+          repo_url = puppetfile_module.remote
+
+          unless PuppetfileResolver::Util.git?
+            resolver_ui.debug { 'Git executible not found, unable to use git clone resolution' }
+
+            return nil
+          end
+          return nil if repo_url.nil?
+          return nil unless valid_http_url?(repo_url)
+
+          metadata_file = 'metadata.json'
+
+          ref = puppetfile_module.ref ||
+                puppetfile_module.tag ||
+                puppetfile_module.commit ||
+                puppetfile_module.branch ||
+                'HEAD'
+
+          resolver_ui.debug { "Querying git repository #{repo_url}" }
+
+          clone_and_read_file(repo_url, ref, metadata_file, config)
+        end
+
+        # @summary clones the git url and reads the file at the given ref
+        #          a temp directory will be created and then destroyed during
+        #          the cloning and reading process
+        # @param ref [String] the git ref, branch, commit, tag
+        # @param file [String] the file you wish to read
+        # @returns [String] the content of the file
+        def self.clone_and_read_file(url, ref, file, config)
+          clone_cmd = ['git', 'clone', '--bare', '--depth=1', '--single-branch']
+          err_msg = ''
+          if config.git.proxy
+            err_msg += " with proxy #{config.git.proxy}: "
+            proxy = "--config \"http.proxy=#{config.git.proxy}\" --config \"https.proxy=#{config.proxy}\""
+            clone_cmd.push(proxy)
+          end
+
+          Dir.mktmpdir(nil, config.git.clone_dir) do |dir|
+            clone_cmd.push("--branch=#{ref}") if ref != 'HEAD'
+            clone_cmd.push(url, dir)
+            out, err_out, process = ::PuppetfileResolver::Util.run_command(clone_cmd)
+            err_msg += out
+            raise err_msg unless process.success?
+            Dir.chdir(dir) do
+              content, err_out, process = ::PuppetfileResolver::Util.run_command(['git', 'show', "#{ref}:#{file}"])
+              raise 'InvalidContent' unless process.success? && content.length > 2
+              return content
+            end
+          end
+        end
+
+        def self.valid_http_url?(url)
+          # uri does not work with git urls, return true
+          return true if url.start_with?('git@')
+
+          uri = URI.parse(url)
+          uri.is_a?(URI::HTTP) && !uri.host.nil?
+        rescue URI::InvalidURIError
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/puppetfile-resolver/spec_searchers/git_configuration.rb
+++ b/lib/puppetfile-resolver/spec_searchers/git_configuration.rb
@@ -3,7 +3,7 @@
 module PuppetfileResolver
   module SpecSearchers
     class GitConfiguration
-      attr_accessor :proxy
+      attr_accessor :proxy, :clone_dir
     end
   end
 end

--- a/lib/puppetfile-resolver/util.rb
+++ b/lib/puppetfile-resolver/util.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'open3'
+
 module PuppetfileResolver
   module Util
     def self.symbolise_object(object)
@@ -42,6 +44,23 @@ module PuppetfileResolver
 
       Net::HTTP.start(*start_args, http_options) { |http| return http.request(Net::HTTP::Get.new(uri)) }
       nil
+    end
+
+    # @summary runs the command on the shell
+    # @param cmd [Array] an array of command and args
+    # @returns [Array] the result of running the comand and the process
+    # @example run_command(['git', '--version'])
+    def self.run_command(cmd)
+      Open3.capture3(*cmd)
+    end
+
+    # @summary checks if git is installed and on the path
+    # @returns [Boolean] true if git is found in the path
+    def self.git?
+      Open3.capture3('git', '--version')
+      true
+    rescue Errno::ENOENT
+      false
     end
   end
 end

--- a/spec/unit/puppetfile-resolver/spec_searchers/git/gclone_spec.rb
+++ b/spec/unit/puppetfile-resolver/spec_searchers/git/gclone_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+require 'puppetfile-resolver/spec_searchers/git/gclone'
+require 'puppetfile-resolver/spec_searchers/git_configuration'
+require 'logger'
+require 'json'
+
+describe PuppetfileResolver::SpecSearchers::Git::GClone do
+  PuppetfileModule = Struct.new(:remote, :ref, :branch, :commit, :tag, keyword_init: true)
+  config = PuppetfileResolver::SpecSearchers::Configuration.new
+  config.local.puppet_module_paths = [File.join(FIXTURES_DIR, 'modulepath')]
+
+  let(:url) do
+    'https://github.com/puppetlabs/puppetlabs-powershell'
+  end
+
+  let(:puppetfile_module) do
+    PuppetfileModule.new(remote: url)
+  end
+
+
+  context 'valid url' do
+    it 'reads metadata' do
+      content = subject.metadata(puppetfile_module, Logger.new(STDERR), config)
+      expect(JSON.parse(content)['name']).to eq('puppetlabs-powershell')
+    end
+
+    context 'with ref' do
+
+      let(:puppetfile_module) do
+        PuppetfileModule.new(remote: url, ref: '2.1.2')
+      end
+
+      it 'reads metadata' do
+        content = subject.metadata(puppetfile_module, Logger.new(STDERR), config)
+        expect(JSON.parse(content)['name']).to eq('puppetlabs-powershell')
+      end
+    end
+  end
+
+  context 'invalid url' do
+    let(:url) do
+      'https://github.com/puppetlabs/puppetlabs-powershellbad'
+    end
+
+    it 'throws exception' do
+      expect{subject.metadata(puppetfile_module, Logger.new(STDERR), config)}
+      .to raise_exception(RuntimeError)
+    end
+  end
+end


### PR DESCRIPTION
Builds on #33 

---

 * Previously the spec search method was limited to just github.com
    and gitlab.com.  Since there are many more git providers and
    internal sources a git clone option was added to support git remotes from
   various sources. 

* It was originally thought that cloning modules would take FOREVER!, Which it actually did with
  some of the sample tests.   Cloning initial took 15 seconds.  With some special git options I 
  was able to reduce this to 1 second.  The git options used where `--bare --single-branch --depth=1 --branch=ref`

* Previous comments in the code discussed adding the git clone ability so this might be a internal issue or ticket that
  can be closed as a result.

* I added my own testing file and added support for ref, commit, branch, and tag as the other classes didn't support those.
