### PR TITLE
Fix bugs in Git spec searchers

### DIFF
--- a/lib/puppetfile-resolver/spec_searchers/git/gclone.rb
+++ b/lib/puppetfile-resolver/spec_searchers/git/gclone.rb
@@ -47,13 +47,13 @@ module PuppetfileResolver
         def self.clone_and_read_file(url, ref, file, config)
           clone_cmd = ['git', 'clone', '--bare', '--depth=1', '--single-branch']
           err_msg = ''
-          if config.git.proxy
-            err_msg += " with proxy #{config.git.proxy}: "
-            proxy = "--config \"http.proxy=#{config.git.proxy}\" --config \"https.proxy=#{config.proxy}\""
+          if config.proxy
+            err_msg += " with proxy #{config.proxy}: "
+            proxy = "--config \"http.proxy=#{config.proxy}\" --config \"https.proxy=#{config.proxy}\""
             clone_cmd.push(proxy)
           end
 
-          Dir.mktmpdir(nil, config.git.clone_dir) do |dir|
+          Dir.mktmpdir(nil, config.clone_dir) do |dir|
             clone_cmd.push("--branch=#{ref}") if ref != 'HEAD'
             clone_cmd.push(url, dir)
             out, err_out, process = ::PuppetfileResolver::Util.run_command(clone_cmd)

--- a/lib/puppetfile-resolver/spec_searchers/git/github.rb
+++ b/lib/puppetfile-resolver/spec_searchers/git/github.rb
@@ -43,7 +43,7 @@ module PuppetfileResolver
 
           if response.code != '200'
             resolver_ui.debug(err_msg + "Expected HTTP Code 200, but received #{response.code}")
-            return ''
+            return nil
           end
           response.body
         end

--- a/lib/puppetfile-resolver/spec_searchers/git/gitlab.rb
+++ b/lib/puppetfile-resolver/spec_searchers/git/gitlab.rb
@@ -45,7 +45,7 @@ module PuppetfileResolver
 
           if response.code != '200'
             resolver_ui.debug(err_msg + "Expected HTTP Code 200, but received #{response.code}")
-            return ''
+            return nil
           end
           response.body
         end

--- a/spec/unit/puppetfile-resolver/spec_searchers/git/gclone_spec.rb
+++ b/spec/unit/puppetfile-resolver/spec_searchers/git/gclone_spec.rb
@@ -6,8 +6,7 @@ require 'json'
 
 describe PuppetfileResolver::SpecSearchers::Git::GClone do
   PuppetfileModule = Struct.new(:remote, :ref, :branch, :commit, :tag, keyword_init: true)
-  config = PuppetfileResolver::SpecSearchers::Configuration.new
-  config.local.puppet_module_paths = [File.join(FIXTURES_DIR, 'modulepath')]
+  config = PuppetfileResolver::SpecSearchers::GitConfiguration.new
 
   let(:url) do
     'https://github.com/puppetlabs/puppetlabs-powershell'
@@ -39,7 +38,7 @@ describe PuppetfileResolver::SpecSearchers::Git::GClone do
 
   context 'invalid url' do
     let(:url) do
-      'https://github.com/puppetlabs/puppetlabs-powershellbad'
+      'https://user:password@github.com/puppetlabs/puppetlabs-powershellbad'
     end
 
     it 'throws exception' do


### PR DESCRIPTION
This fixes a bug that was incorrectly fetching config from the
`GitConfiguration` class in the `GClone` spec searcher.

This also fixes a bug in the `GitHub` and `GitLab` spec searchers that
prevented the spec searcher from using the `GitLab` and `GClone` spec
searchers. Previously, if either spec searcher returned a non-200
response code, they would return an empty string. This prevented the
`Git` spec searcher from using any other spec searcher other than
`GitHub` to retrieve module metadata.