### PR TITLE
Support using commits for `GClone` spec searcher, correctly print errors

### DIFF
--- a/lib/puppetfile-resolver/spec_searchers/git/gclone.rb
+++ b/lib/puppetfile-resolver/spec_searchers/git/gclone.rb
@@ -57,7 +57,7 @@ module PuppetfileResolver
             clone_cmd.push("--branch=#{ref}") if ref != 'HEAD'
             clone_cmd.push(url, dir)
             out, err_out, process = ::PuppetfileResolver::Util.run_command(clone_cmd)
-            err_msg += out
+            err_msg += err_out
             raise err_msg unless process.success?
             Dir.chdir(dir) do
               content, err_out, process = ::PuppetfileResolver::Util.run_command(['git', 'show', "#{ref}:#{file}"])

--- a/spec/unit/puppetfile-resolver/spec_searchers/git/gclone_spec.rb
+++ b/spec/unit/puppetfile-resolver/spec_searchers/git/gclone_spec.rb
@@ -44,6 +44,18 @@ describe PuppetfileResolver::SpecSearchers::Git::GClone do
         expect(JSON.parse(content)['name']).to eq('puppetlabs-powershell')
       end
     end
+
+    context 'with invalid ref' do
+      let(:puppetfile_module) do
+        PuppetfileModule.new(remote: url, ref: '8f7d5ea3ef49dadc5e166d5d802d091abc4b02bc')
+      end
+
+      it 'errors gracefully' do
+        expect { subject.metadata(puppetfile_module, Logger.new(STDERR), config) }.to raise_error(
+          /Could not find metadata\.json for ref .* at .*/
+        )
+      end
+    end
   end
 
   context 'invalid url' do

--- a/spec/unit/puppetfile-resolver/spec_searchers/git/gclone_spec.rb
+++ b/spec/unit/puppetfile-resolver/spec_searchers/git/gclone_spec.rb
@@ -23,10 +23,20 @@ describe PuppetfileResolver::SpecSearchers::Git::GClone do
       expect(JSON.parse(content)['name']).to eq('puppetlabs-powershell')
     end
 
-    context 'with ref' do
-
+    context 'with tag' do
       let(:puppetfile_module) do
         PuppetfileModule.new(remote: url, ref: '2.1.2')
+      end
+
+      it 'reads metadata' do
+        content = subject.metadata(puppetfile_module, Logger.new(STDERR), config)
+        expect(JSON.parse(content)['name']).to eq('puppetlabs-powershell')
+      end
+    end
+
+    context 'with commit' do
+      let(:puppetfile_module) do
+        PuppetfileModule.new(remote: url, ref: '9276de695798097e8471b877a18df27f764eecda')
       end
 
       it 'reads metadata' do


### PR DESCRIPTION
### Add stderr to error message in GClone spec searcher
This fixes a bug in the `GClone` spec searcher that was adding the
contents of stdout to the error message raised when cloning the git
repository fails. Now, the contents of stderr are added to the error
message.

### Support using commits for GClone spec searcher
This fixes a bug with the `GClone` spec searcher that caused `git clone`
to fail when provided a commit to clone. Because `git clone` does
not support cloning a specific commit (using a SHA1), it's necessary to
clone the entire repository. This updates the `git clone` command used
by the spec searcher accordingly.