### PR TITLE
(FEAT) -  Add Ruby 3.x compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ group :development do
   gem "yard",          :require => false
   gem 'redcarpet',     :require => false
   gem 'github-markup', :require => false
+  # webrick is no longer bundled with ruby 3.x or later
+  gem "webrick",       :require => false
 end
 
 # Evaluate Gemfile.local and ~/.gemfile if they exist

--- a/lib/puppetfile-resolver/puppetfile/parser/r10k_eval.rb
+++ b/lib/puppetfile-resolver/puppetfile/parser/r10k_eval.rb
@@ -21,7 +21,7 @@ module PuppetfileResolver
           rescue StandardError, LoadError => e
             # Find the originating error from within the puppetfile
             loc = e.backtrace_locations
-                   .select { |item| item.absolute_path == PUPPETFILE_MONIKER }
+                   .select { |item| item.path == PUPPETFILE_MONIKER }
                    .first
             start_line_number = loc.nil? ? 0 : loc.lineno - 1 # Line numbers from ruby are base 1
             end_line_number = loc.nil? ? puppetfile_contents.lines.count - 1 : loc.lineno - 1 # Line numbers from ruby are base 1

--- a/lib/puppetfile-resolver/puppetfile/parser/r10k_eval/dsl.rb
+++ b/lib/puppetfile-resolver/puppetfile/parser/r10k_eval/dsl.rb
@@ -41,7 +41,7 @@ module PuppetfileResolver
 
           def find_load_line_number
             loc = Kernel.caller_locations
-                        .find { |call_loc| call_loc.absolute_path == ::PuppetfileResolver::Puppetfile::Parser::R10KEval::PUPPETFILE_MONIKER }
+                        .find { |call_loc| call_loc.path == ::PuppetfileResolver::Puppetfile::Parser::R10KEval::PUPPETFILE_MONIKER }
             loc.nil? ? 0 : loc.lineno - 1 # Line numbers from ruby are base 1
           end
         end


### PR DESCRIPTION
It was noted that this gem was failing spec tests when running on ruby 3.x and above.
The root cause of this issue seemed to be the `absolute_path` property found on the `Thread::Backtrace::Location` class. 
Updating this to `path` allows spec tests to pass on both ruby 2.x and 3.x.

Can confirm that when consumed by other tools, this also works as expected. Open to suggested changes and improvements.